### PR TITLE
Add `CustomModel` interface

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -24,11 +24,13 @@ type DecodeError string
 
 // Decode decodes an image in the imretro format.
 //
-// Custom color models can be used instead of the default color models. See the
-// documentation for the model types for more details. If the decoded image
-// contains an in-image palette, the model will be generated from that instead
-// of the custom value passed or the default models.
-func Decode(r io.Reader, customModels ModelMap) (Image, error) {
+// Custom color models can be used instead of the default color models. For
+// simplicity's sake, a single ColorModel can be passed as the CustomModel. If
+// multiple PixelMode values are expected, it is recommended to use a ModelMap
+// for the CustomModel. See the documentation for the model types for more
+// details. If the decoded image contains an in-image palette, the model will be
+// generated from that instead of the custom value passed or the default models.
+func Decode(r io.Reader, customModels CustomModel) (Image, error) {
 	config, err := DecodeConfig(r, customModels)
 	if err != nil {
 		return nil, err
@@ -45,7 +47,7 @@ func Decode(r io.Reader, customModels ModelMap) (Image, error) {
 // without decoding the entire image.
 //
 // Custom color models can be used instead of the default model.
-func DecodeConfig(r io.Reader, customModels ModelMap) (image.Config, error) {
+func DecodeConfig(r io.Reader, customModels CustomModel) (image.Config, error) {
 	var buff []byte
 	var err error
 	modelMap := customModels
@@ -70,7 +72,7 @@ func DecodeConfig(r io.Reader, customModels ModelMap) (image.Config, error) {
 	var model color.Model
 	if !hasPalette {
 		var ok bool
-		model, ok = modelMap[bitsPerPixel]
+		model, ok = modelMap.ColorModel(bitsPerPixel)
 		if !ok {
 			err = MissingModelError(bitsPerPixel)
 		}

--- a/example_decode_test.go
+++ b/example_decode_test.go
@@ -1,0 +1,52 @@
+package imretro_test
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"io"
+	"log"
+
+	_ "github.com/imretro/go" // register imretro format
+)
+
+func Example_decode() {
+	var reader io.Reader = bytes.NewBuffer(ImgBytes)
+	img, format, err := image.Decode(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Format: %s\n", format)
+
+	bounds := img.Bounds()
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, _ := img.At(x, y).RGBA()
+			fmt.Printf("r = %04X, g = %04X, b = %04X\n", r, g, b)
+		}
+	}
+
+	// Output:
+	// Format: imretro
+	// r = FFFF, g = FFFF, b = FFFF
+	// r = 0000, g = 0000, b = 0000
+	// r = 0000, g = 0000, b = 0000
+	// r = FFFF, g = FFFF, b = FFFF
+}
+
+func Example_decode_config() {
+	var reader io.Reader = bytes.NewBuffer(ImgBytes)
+	config, format, err := image.DecodeConfig(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Format: %s\n", format)
+	fmt.Printf("width: %d\nheight: %d\n", config.Width, config.Height)
+
+	// Output:
+	// Format: imretro
+	// width: 2
+	// height: 2
+}

--- a/example_models_test.go
+++ b/example_models_test.go
@@ -1,0 +1,75 @@
+package imretro_test
+
+import (
+	"bytes"
+	"fmt"
+	"image/color"
+	"io"
+	"log"
+
+	imretro "github.com/imretro/go"
+)
+
+// Custom models can be used when decoding to define your own palette.
+// In this example, instead of using the default black & white 1-bit-pixel
+// palette, black and green palettes are passed.
+func ExampleCustomModel_model_map() {
+	black := color.Gray{0}
+	green := color.RGBA{0, 0xFF, 0, 0xFF}
+	custom := imretro.ModelMap{
+		imretro.OneBit: imretro.ColorModel{black, green},
+		imretro.TwoBit: imretro.ColorModel{
+			black, color.RGBA{0, 0x55, 0, 0}, color.RGBA{0, 0xAA, 0, 0}, black,
+		},
+		imretro.EightBit: make(imretro.ColorModel, 256),
+	}
+	var reader io.Reader = bytes.NewBuffer(ImgBytes)
+	img, err := imretro.Decode(reader, custom)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bounds := img.Bounds()
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, _ := img.At(x, y).RGBA()
+			fmt.Printf("r = %04X, g = %04X, b = %04X\n", r, g, b)
+		}
+	}
+
+	// Output:
+	// r = 0000, g = FFFF, b = 0000
+	// r = 0000, g = 0000, b = 0000
+	// r = 0000, g = 0000, b = 0000
+	// r = 0000, g = FFFF, b = 0000
+}
+
+// If the pixel mode is predictable, a single ColorModel can be passed. In this
+// example, it is assumed that the image will always be in 1-bit-pixel mode
+// (two colors).
+func ExampleCustomModel_single_model() {
+	black := color.Gray{0}
+	green := color.RGBA{0, 0xFF, 0, 0xFF}
+	custom := imretro.ColorModel{black, green}
+	var reader io.Reader = bytes.NewBuffer(ImgBytes)
+	img, err := imretro.Decode(reader, custom)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bounds := img.Bounds()
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, _ := img.At(x, y).RGBA()
+			fmt.Printf("r = %04X, g = %04X, b = %04X\n", r, g, b)
+		}
+	}
+
+	// Output:
+	// r = 0000, g = FFFF, b = 0000
+	// r = 0000, g = 0000, b = 0000
+	// r = 0000, g = 0000, b = 0000
+	// r = 0000, g = FFFF, b = 0000
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,61 +1,12 @@
 package imretro_test
 
-import (
-	"bytes"
-	"fmt"
-	"image"
-	"io"
-	"log"
-
-	_ "github.com/imretro/go" // register imretro format
-)
+import imretro "github.com/imretro/go"
 
 // ImgBytes declares a 2x2 image with no in-file palette, 1 bit per pixel, and
 // an alternating white/black checkerboard pattern.
 var ImgBytes = []byte{
 	'I', 'M', 'R', 'E', 'T', 'R', 'O', // Signature
-	0x00, // Mode
+	imretro.OneBit,   // Mode
 	0x00, 0x20, 0x02, // Width & Height (2 12-bit numbers)
 	0b1001_0000, // Pixels (on, off, off, on, ignored)
-}
-
-func Example_decode() {
-	var reader io.Reader = bytes.NewBuffer(ImgBytes)
-	img, format, err := image.Decode(reader)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("Format: %s\n", format)
-
-	bounds := img.Bounds()
-
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			r, g, b, _ := img.At(x, y).RGBA()
-			fmt.Printf("r = %04X, g = %04X, b = %04X\n", r, g, b)
-		}
-	}
-
-	// Output:
-	// Format: imretro
-	// r = FFFF, g = FFFF, b = FFFF
-	// r = 0000, g = 0000, b = 0000
-	// r = 0000, g = 0000, b = 0000
-	// r = FFFF, g = FFFF, b = FFFF
-}
-
-func Example_decode_config() {
-	var reader io.Reader = bytes.NewBuffer(ImgBytes)
-	config, format, err := image.DecodeConfig(reader)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Format: %s\n", format)
-	fmt.Printf("width: %d\nheight: %d\n", config.Width, config.Height)
-
-	// Output:
-	// Format: imretro
-	// width: 2
-	// height: 2
 }

--- a/models.go
+++ b/models.go
@@ -10,8 +10,22 @@ import (
 	"github.com/imretro/go/internal/util"
 )
 
+// CustomModel is a type that converts a pixel mode to a color.Model.  It should
+// be used to override default palettes/color models.
+type CustomModel interface {
+	// ColorModel gets a color.Model from a PixelMode. Ok should be true if the
+	// color.Model could be returned, and false if it couldn't.
+	ColorModel(PixelMode) (model color.Model, ok bool)
+}
+
 // ModelMap maps bit modes to color models.
-type ModelMap = map[PixelMode]color.Model
+type ModelMap map[PixelMode]color.Model
+
+// ColorModel gets the mapped color model.
+func (m ModelMap) ColorModel(mode PixelMode) (model color.Model, ok bool) {
+	model, ok = m[mode]
+	return
+}
 
 // ErrUnknownModel is raised when an unknown color model is interpreted.
 var ErrUnknownModel = errors.New("Color model not recognized")
@@ -102,6 +116,11 @@ func (model ColorModel) Convert(c color.Color) color.Color {
 		return noColor
 	}
 	return model[index]
+}
+
+// ColorModel will always return itself and ok.
+func (model ColorModel) ColorModel(PixelMode) (self color.Model, ok bool) {
+	return model, true
 }
 
 func init() {


### PR DESCRIPTION
Allows a single model to be passed as well as a map of models for the
custom model(s) when decoding.
