### PR TITLE
Handle decoding image with missing pixels

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -31,8 +31,14 @@ func Decode(r io.Reader, customModels CustomModel) (Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	pixels, err := io.ReadAll(r)
-	if err != nil {
+	area := config.Width * config.Height
+	pixelsForByte := 8 / config.ColorModel.(ColorModel).BitsPerPixel()
+	bytesNeeded := area / pixelsForByte
+	if area%pixelsForByte != 0 {
+		bytesNeeded++
+	}
+	pixels := make([]byte, bytesNeeded)
+	if _, err := io.ReadFull(r, pixels); err != nil {
 		return nil, err
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -667,6 +667,28 @@ func TestDecodeMissingModel(t *testing.T) {
 	}
 }
 
+// TestDecodeNotEnoughPixels tests that the decoder will return an error if
+// there are not enough pixels for the dimensions.
+//
+// Issue #16
+func TestDecodeNotEnoughPixels(t *testing.T) {
+	tests := []struct {
+		mode  ModeFlag
+		bytes int
+	}{
+		{OneBit, 12},
+		{TwoBit, 24},
+		{EightBit, 99},
+	}
+
+	for _, tt := range tests {
+		r := MakeImretroReader(tt.mode, nil, 10, 10, make([]byte, tt.bytes))
+		if _, err := Decode(r, nil); err == nil {
+			t.Errorf(`%d bytes for pixel mode 0b%08b: err = nil`, tt.bytes, tt.mode)
+		}
+	}
+}
+
 // TestDecodeReaderError tests that a reader error would be returned if it
 // occurs.
 func TestDecodeReaderError(t *testing.T) {

--- a/imretro.go
+++ b/imretro.go
@@ -114,13 +114,7 @@ func (i imretroImage) PixelMode() PixelMode {
 
 // BitsPerPixel returns the number of bits used for each pixel.
 func (i imretroImage) BitsPerPixel() int {
-	switch i.ColorModel().(ColorModel).PixelMode() {
-	case OneBit:
-		return 1
-	case TwoBit:
-		return 2
-	}
-	return 8
+	return i.ColorModel().(ColorModel).BitsPerPixel()
 }
 
 // ColorModel returns the Image's color model.

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"image/color"
+	"math/bits"
 
 	"github.com/spenserblack/go-byteutils"
 
@@ -67,6 +68,11 @@ func (model ColorModel) PixelMode() PixelMode {
 		return TwoBit
 	}
 	return EightBit
+}
+
+// BitsPerPixel returns the number of bits used for each pixel.
+func (model ColorModel) BitsPerPixel() int {
+	return bits.TrailingZeros(uint(len(model)))
 }
 
 // NewOneBitColorModel creates a new color model for 1-bit-pixel images.


### PR DESCRIPTION
Checks if there are enough pixels to decode, and returns an `error` if not.

Fixes #16
